### PR TITLE
Implement LiquidationScenarioCalculation service

### DIFF
--- a/backend/app/services/liquidation_scenario_calculation.rb
+++ b/backend/app/services/liquidation_scenario_calculation.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+class LiquidationScenarioCalculation
+  def initialize(scenario)
+    @scenario = scenario
+    @company = scenario.company
+  end
+
+  def process
+    LiquidationPayout.transaction do
+      scenario.liquidation_payouts.destroy_all
+      calculate_equity_payouts
+      calculate_convertible_payouts
+    end
+    scenario
+  end
+
+  private
+    attr_reader :scenario, :company
+
+    def calculate_equity_payouts
+      remaining = scenario.exit_amount_cents.to_d
+      payouts = Hash.new { |h, k| h[k] = { preference: 0.to_d, participation: 0.to_d, common: 0.to_d, shares: 0 } }
+
+      share_data.each do |data|
+        payouts[[data.company_investor_id, data.share_class_id]][:shares] = data.total_shares
+      end
+
+      share_classes_by_rank.each do |share_class|
+        holdings = share_data.select { |d| d.share_class_id == share_class.id }
+        next if holdings.empty?
+
+        pref_per_share = (share_class.original_issue_price_in_dollars.to_d * 100) * share_class.liquidation_preference_multiple.to_d
+        total_pref = pref_per_share * holdings.sum(&:total_shares)
+        amount_to_pay = [total_pref, remaining].min
+        ratio = total_pref.zero? ? 0 : amount_to_pay / total_pref
+        holdings.each do |h|
+          paid = (pref_per_share * h.total_shares) * ratio
+          payouts[[h.company_investor_id, h.share_class_id]][:preference] += paid
+        end
+        remaining -= amount_to_pay
+        break if remaining.zero?
+      end
+
+      eligible_holdings = share_data.select do |d|
+        sc = share_class_map[d.share_class_id]
+        !sc.preferred || sc.participating
+      end
+      total_common_shares = eligible_holdings.sum(&:total_shares)
+      per_share_common = total_common_shares.zero? ? 0 : remaining / total_common_shares
+
+      eligible_holdings.each do |h|
+        sc = share_class_map[h.share_class_id]
+        amt = per_share_common * h.total_shares
+        if sc.preferred && sc.participating
+          cap = if sc.participation_cap_multiple
+                   (sc.original_issue_price_in_dollars.to_d * 100 * sc.participation_cap_multiple.to_d * h.total_shares) -
+                     payouts[[h.company_investor_id, h.share_class_id]][:preference]
+                 end
+          amt = [amt, cap].min if cap && cap.positive?
+          payouts[[h.company_investor_id, h.share_class_id]][:participation] += amt
+        else
+          payouts[[h.company_investor_id, h.share_class_id]][:common] += amt
+        end
+      end
+
+      payouts.each do |(investor_id, sc_id), values|
+        total = values.values_at(:preference, :participation, :common).sum
+        LiquidationPayout.create!(
+          liquidation_scenario: scenario,
+          company_investor_id: investor_id,
+          share_class: share_class_map[sc_id].name,
+          security_type: 'equity',
+          number_of_shares: values[:shares],
+          payout_amount_cents: total.round,
+          liquidation_preference_amount: values[:preference],
+          participation_amount: values[:participation],
+          common_proceeds_amount: values[:common]
+        )
+      end
+    end
+
+    def calculate_convertible_payouts
+      total_shares = share_data.sum(&:total_shares) + company.convertible_securities.sum(:implied_shares)
+      share_price = total_shares.zero? ? 0 : scenario.exit_amount_cents.to_d / total_shares
+
+      company.convertible_securities.find_each do |security|
+        principal = security.principal_value_in_cents.to_d
+        converted = share_price * security.implied_shares.to_d
+        amount = [principal, converted].max
+        LiquidationPayout.create!(
+          liquidation_scenario: scenario,
+          company_investor: security.company_investor,
+          security_type: 'convertible',
+          payout_amount_cents: amount.round,
+          liquidation_preference_amount: 0,
+          participation_amount: 0,
+          common_proceeds_amount: 0
+        )
+      end
+    end
+
+    def share_classes_by_rank
+      company.share_classes.order(Arel.sql('COALESCE(seniority_rank, 1_000_000) ASC'))
+    end
+
+    def share_class_map
+      @share_class_map ||= company.share_classes.index_by(&:id)
+    end
+
+    def share_data
+      @share_data ||=
+        company
+          .share_holdings
+          .joins(:share_class)
+          .group(:company_investor_id, :share_class_id)
+          .select('company_investor_id, share_class_id, SUM(number_of_shares) AS total_shares')
+    end
+end

--- a/backend/spec/services/liquidation_scenario_calculation_spec.rb
+++ b/backend/spec/services/liquidation_scenario_calculation_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe LiquidationScenarioCalculation do
+  describe '#process' do
+    context 'with simple common stock' do
+      let(:company) { create(:company) }
+      let(:common_class) { create(:share_class, company:) }
+      let(:investor1) { create(:company_investor, company:) }
+      let(:investor2) { create(:company_investor, company:) }
+      let(:scenario) { create(:liquidation_scenario, company:, exit_amount_cents: 100_00) }
+
+      before do
+        create(:share_holding, company_investor: investor1, share_class: common_class, number_of_shares: 60)
+        create(:share_holding, company_investor: investor2, share_class: common_class, number_of_shares: 40)
+        described_class.new(scenario).process
+      end
+
+      it 'creates a payout per investor' do
+        expect(scenario.liquidation_payouts.count).to eq(2)
+      end
+
+      it 'distributes the entire exit amount' do
+        expect(scenario.liquidation_payouts.sum(:payout_amount_cents)).to eq(100_00)
+      end
+
+      it 'pays investor1 pro rata' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: investor1)
+        expect(payout.payout_amount_cents).to eq(60_00)
+      end
+
+      it 'pays investor2 pro rata' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: investor2)
+        expect(payout.payout_amount_cents).to eq(40_00)
+      end
+
+      it 'records equity security type' do
+        expect(scenario.liquidation_payouts.pluck(:security_type).uniq).to eq(['equity'])
+      end
+    end
+
+    context 'with preferred stock' do
+      let(:company) { create(:company) }
+      let(:preferred_class) { create(:share_class, :preferred, company:, original_issue_price_in_dollars: 1.0) }
+      let(:common_class) { create(:share_class, company:) }
+      let(:pref_investor) { create(:company_investor, company:) }
+      let(:common_investor) { create(:company_investor, company:) }
+      let(:scenario) { create(:liquidation_scenario, company:, exit_amount_cents: 150_00) }
+
+      before do
+        create(:share_holding, company_investor: pref_investor, share_class: preferred_class, number_of_shares: 100)
+        create(:share_holding, company_investor: common_investor, share_class: common_class, number_of_shares: 100)
+        described_class.new(scenario).process
+      end
+
+      it 'creates payouts for both investors' do
+        expect(scenario.liquidation_payouts.count).to eq(2)
+      end
+
+      it 'gives preferred investor preference first' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: pref_investor)
+        expect(payout.liquidation_preference_amount.to_i).to eq(100_00)
+      end
+
+      it 'common investor receives remainder' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: common_investor)
+        expect(payout.payout_amount_cents).to eq(50_00)
+      end
+
+      it 'totals to exit amount' do
+        expect(scenario.liquidation_payouts.sum(:payout_amount_cents)).to eq(150_00)
+      end
+    end
+
+    context 'with participating preferred with cap' do
+      let(:company) { create(:company) }
+      let(:preferred_class) do
+        create(:share_class, :preferred, :participating, company:, original_issue_price_in_dollars: 1.0, participation_cap_multiple: 2.0)
+      end
+      let(:common_class) { create(:share_class, company:) }
+      let(:pref_investor) { create(:company_investor, company:) }
+      let(:common_investor) { create(:company_investor, company:) }
+      let(:scenario) { create(:liquidation_scenario, company:, exit_amount_cents: 300_00) }
+
+      before do
+        create(:share_holding, company_investor: pref_investor, share_class: preferred_class, number_of_shares: 100)
+        create(:share_holding, company_investor: common_investor, share_class: common_class, number_of_shares: 100)
+        described_class.new(scenario).process
+      end
+
+      it 'pays liquidation preference' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: pref_investor)
+        expect(payout.liquidation_preference_amount.to_i).to eq(100_00)
+      end
+
+      it 'pays participation up to cap' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: pref_investor)
+        expect(payout.participation_amount.to_i).to eq(100_00)
+      end
+
+      it 'pays common holder remaining amount' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: common_investor)
+        expect(payout.common_proceeds_amount.to_i).to eq(100_00)
+      end
+
+      it 'sums to exit amount' do
+        expect(scenario.liquidation_payouts.sum(:payout_amount_cents)).to eq(300_00)
+      end
+    end
+
+    context 'with convertible securities' do
+      let(:company) { create(:company) }
+      let(:common_class) { create(:share_class, company:) }
+      let(:investor) { create(:company_investor, company:) }
+      let(:convertible_investor) { create(:company_investor, company:) }
+      let(:scenario) { create(:liquidation_scenario, company:, exit_amount_cents: 40_000) }
+
+      before do
+        create(:share_holding, company_investor: investor, share_class: common_class, number_of_shares: 100)
+        investment = create(:convertible_investment, company:)
+        create(:convertible_security, company_investor: convertible_investor, convertible_investment: investment, principal_value_in_cents: 10_000, implied_shares: 100)
+        described_class.new(scenario).process
+      end
+
+      it 'creates two payouts' do
+        expect(scenario.liquidation_payouts.count).to eq(2)
+      end
+
+      it 'chooses conversion when beneficial' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: convertible_investor)
+        expect(payout.payout_amount_cents).to eq(20_000)
+      end
+
+      it 'common investor receives remaining amount' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: investor)
+        expect(payout.payout_amount_cents).to eq(20_000)
+      end
+
+      it 'records convertible security type' do
+        payout = scenario.liquidation_payouts.find_by(company_investor: convertible_investor)
+        expect(payout.security_type).to eq('convertible')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add liquidation scenario calculation service
- compute payout waterfall for liquidation scenarios
- support liquid prefs, participating shares, and convertibles
- add comprehensive service spec

## Testing
- `bundle exec rspec spec/services/liquidation_scenario_calculation_spec.rb --format documentation` *(fails: rbenv ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68780d1b37ac8327a617b1af0df39683