### PR TITLE
Implement liquidation scenarios API layer

### DIFF
--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -2568,3 +2568,64 @@ export const companyUpdatesRelations = relations(companyUpdates, ({ one }) => ({
     references: [companies.id],
   }),
 }));
+
+export const liquidationScenarios = pgTable("liquidation_scenarios", {
+  id: bigserial("id", { mode: "bigint" }).primaryKey(),
+  companyId: bigint("company_id", { mode: "bigint" })
+    .notNull()
+    .references(() => companies.id),
+  externalId: varchar("external_id", { length: 255 }).notNull().unique(),
+  name: varchar("name", { length: 255 }).notNull(),
+  description: text("description"),
+  exitAmountCents: bigint("exit_amount_cents", { mode: "bigint" }).notNull(),
+  exitDate: date("exit_date", { mode: "date" }).notNull(),
+  status: varchar("status", { length: 50 }).notNull().default("draft"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const liquidationPayouts = pgTable("liquidation_payouts", {
+  id: bigserial("id", { mode: "bigint" }).primaryKey(),
+  liquidationScenarioId: bigint("liquidation_scenario_id", { mode: "bigint" })
+    .notNull()
+    .references(() => liquidationScenarios.id),
+  companyInvestorId: bigint("company_investor_id", { mode: "bigint" })
+    .notNull()
+    .references(() => companyInvestors.id),
+  shareClass: varchar("share_class", { length: 255 }),
+  securityType: varchar("security_type", { length: 50 }).notNull(),
+  numberOfShares: bigint("number_of_shares", { mode: "bigint" }),
+  payoutAmountCents: bigint("payout_amount_cents", { mode: "bigint" }).notNull(),
+  liquidationPreferenceAmount: decimal("liquidation_preference_amount", { precision: 20, scale: 2 }),
+  participationAmount: decimal("participation_amount", { precision: 20, scale: 2 }),
+  commonProceedsAmount: decimal("common_proceeds_amount", { precision: 20, scale: 2 }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const liquidationScenariosRelations = relations(liquidationScenarios, ({ one, many }) => ({
+  company: one(companies, {
+    fields: [liquidationScenarios.companyId],
+    references: [companies.id],
+  }),
+  liquidationPayouts: many(liquidationPayouts),
+}));
+
+export const liquidationPayoutsRelations = relations(liquidationPayouts, ({ one }) => ({
+  liquidationScenario: one(liquidationScenarios, {
+    fields: [liquidationPayouts.liquidationScenarioId],
+    references: [liquidationScenarios.id],
+  }),
+  companyInvestor: one(companyInvestors, {
+    fields: [liquidationPayouts.companyInvestorId],
+    references: [companyInvestors.id],
+  }),
+}));

--- a/frontend/trpc/routes/liquidationScenarios.ts
+++ b/frontend/trpc/routes/liquidationScenarios.ts
@@ -1,0 +1,146 @@
+import { createRouter, companyProcedure } from "../index";
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { db } from "@/db";
+import { liquidationScenarios, liquidationPayouts, companyInvestors, users } from "@/db/schema";
+import { eq, and, desc } from "drizzle-orm";
+import { createInsertSchema } from "drizzle-zod";
+
+const createLiquidationScenarioSchema = createInsertSchema(liquidationScenarios).pick({
+  name: true,
+  description: true,
+  exitAmountCents: true,
+  exitDate: true,
+}).extend({
+  exitAmountCents: z.coerce.bigint().positive(),
+  exitDate: z.string().datetime(),
+});
+
+export const liquidationScenariosRouter = createRouter({
+  run: companyProcedure
+    .input(createLiquidationScenarioSchema)
+    .mutation(async ({ ctx, input }) => {
+      // Check authorization - only administrators can create scenarios
+      if (!ctx.companyAdministrator) {
+        throw new TRPCError({ 
+          code: "FORBIDDEN",
+          message: "Only administrators can create liquidation scenarios" 
+        });
+      }
+
+      // Create scenario in database
+      const [scenario] = await db
+        .insert(liquidationScenarios)
+        .values({
+          companyId: BigInt(ctx.company.id),
+          externalId: `ls_${Math.random().toString(36).substring(2, 15)}`, // Simple ID generation
+          name: input.name,
+          description: input.description,
+          exitAmountCents: input.exitAmountCents,
+          exitDate: new Date(input.exitDate),
+          status: "draft",
+        })
+        .returning();
+
+      // TODO: Call Rails backend to run calculation service
+      // This would normally be an API call to Rails:
+      // await fetch(`${RAILS_API_URL}/api/liquidation_scenarios/${scenario.id}/calculate`, { method: 'POST' })
+      
+      // For now, return the created scenario
+      return {
+        id: scenario.id.toString(),
+        externalId: scenario.externalId,
+        name: scenario.name,
+        description: scenario.description,
+        exitAmountCents: scenario.exitAmountCents.toString(),
+        exitDate: scenario.exitDate.toISOString(),
+        status: scenario.status,
+        createdAt: scenario.createdAt.toISOString(),
+        updatedAt: scenario.updatedAt.toISOString(),
+      };
+    }),
+
+  show: companyProcedure
+    .input(z.object({
+      scenarioId: z.string(), // Can be either id or externalId
+    }))
+    .query(async ({ ctx, input }) => {
+      // Try to parse as bigint for numeric ID
+      const isNumericId = /^\d+$/.test(input.scenarioId);
+      
+      const scenario = await db.query.liquidationScenarios.findFirst({
+        where: and(
+          eq(liquidationScenarios.companyId, BigInt(ctx.company.id)),
+          isNumericId 
+            ? eq(liquidationScenarios.id, BigInt(input.scenarioId))
+            : eq(liquidationScenarios.externalId, input.scenarioId)
+        ),
+        with: {
+          liquidationPayouts: {
+            with: {
+              companyInvestor: {
+                with: {
+                  user: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!scenario) {
+        throw new TRPCError({ 
+          code: "NOT_FOUND",
+          message: "Liquidation scenario not found" 
+        });
+      }
+
+      // Transform the data to match frontend expectations
+      return {
+        id: scenario.id.toString(),
+        externalId: scenario.externalId,
+        name: scenario.name,
+        description: scenario.description,
+        exitAmountCents: scenario.exitAmountCents.toString(),
+        exitDate: scenario.exitDate.toISOString(),
+        status: scenario.status,
+        createdAt: scenario.createdAt.toISOString(),
+        updatedAt: scenario.updatedAt.toISOString(),
+        payouts: scenario.liquidationPayouts.map(payout => ({
+          id: payout.id.toString(),
+          investorName: payout.companyInvestor.user?.name || "Unknown",
+          shareClass: payout.shareClass,
+          securityType: payout.securityType,
+          numberOfShares: payout.numberOfShares?.toString(),
+          payoutAmountCents: payout.payoutAmountCents.toString(),
+          liquidationPreferenceAmount: payout.liquidationPreferenceAmount,
+          participationAmount: payout.participationAmount,
+          commonProceedsAmount: payout.commonProceedsAmount,
+        })),
+      };
+    }),
+
+  list: companyProcedure
+    .input(z.object({
+      limit: z.number().min(1).max(100).default(20),
+      offset: z.number().min(0).default(0),
+    }))
+    .query(async ({ ctx, input }) => {
+      const scenarios = await db.query.liquidationScenarios.findMany({
+        where: eq(liquidationScenarios.companyId, BigInt(ctx.company.id)),
+        orderBy: [desc(liquidationScenarios.createdAt)],
+        limit: input.limit,
+        offset: input.offset,
+      });
+
+      return scenarios.map(scenario => ({
+        id: scenario.id.toString(),
+        externalId: scenario.externalId,
+        name: scenario.name,
+        exitAmountCents: scenario.exitAmountCents.toString(),
+        exitDate: scenario.exitDate.toISOString(),
+        status: scenario.status,
+        createdAt: scenario.createdAt.toISOString(),
+      }));
+    }),
+});

--- a/frontend/trpc/server.ts
+++ b/frontend/trpc/server.ts
@@ -24,6 +24,7 @@ import { quickbooksRouter } from "./routes/quickbooks";
 import { shareHoldingsRouter } from "./routes/shareHoldings";
 import { tenderOffersRouter } from "./routes/tenderOffers";
 import { usersRouter } from "./routes/users";
+import { liquidationScenariosRouter } from "./routes/liquidationScenarios";
 import { createClient } from "./shared";
 import { createCallerFactory, createRouter } from "./";
 
@@ -42,6 +43,7 @@ export const appRouter = createRouter({
   dividendRounds: dividendRoundsRouter,
   equityGrantExercises: equityGrantExercisesRouter,
   tenderOffers: tenderOffersRouter,
+  liquidationScenarios: liquidationScenariosRouter,
 
   optionPools: optionPoolsRouter,
   companyUpdates: companyUpdatesRouter,

--- a/frontend/types/liquidationScenario.ts
+++ b/frontend/types/liquidationScenario.ts
@@ -1,0 +1,27 @@
+export interface LiquidationScenario {
+  id: string;
+  externalId: string;
+  name: string;
+  description?: string;
+  exitAmountCents: string;
+  exitDate: string;
+  status: "draft" | "final";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LiquidationPayout {
+  id: string;
+  investorName: string;
+  shareClass?: string;
+  securityType: "equity" | "convertible";
+  numberOfShares?: string;
+  payoutAmountCents: string;
+  liquidationPreferenceAmount?: string;
+  participationAmount?: string;
+  commonProceedsAmount?: string;
+}
+
+export interface LiquidationScenarioWithPayouts extends LiquidationScenario {
+  payouts: LiquidationPayout[];
+}


### PR DESCRIPTION
## Summary
- extend Drizzle schema with liquidation scenario tables
- add related relations
- create liquidationScenarios tRPC router
- register router in server
- define frontend types for liquidation scenarios

## Testing
- `pnpm lint-fast` *(fails: Request was cancelled due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_687818f3df1c8327972b2b82da05382b