### PR TITLE
Add liquidation waterfall frontend UI

### DIFF
--- a/frontend/app/equity/index.ts
+++ b/frontend/app/equity/index.ts
@@ -27,6 +27,9 @@ export const navLinks = (user: CurrentUser, company: Company): TabLink[] => {
       : company.flags.includes("dividends") && (isAdmin || isLawyer)
         ? { label: "Dividends", route: "/equity/dividend_rounds" }
         : null,
+    company.flags.includes("liquidation_scenarios") && (isAdmin || isLawyer)
+      ? { label: "Waterfall", route: "/equity/waterfall" }
+      : null,
     company.flags.includes("tender_offers") && (isAdmin || isInvestor)
       ? { label: "Buybacks", route: "/equity/tender_offers" }
       : null,

--- a/frontend/app/equity/waterfall/[id]/page.tsx
+++ b/frontend/app/equity/waterfall/[id]/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { Download } from "lucide-react";
+import { useParams } from "next/navigation";
+import React, { useMemo } from "react";
+import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
+import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
+import { Button } from "@/components/ui/button";
+import { useCurrentCompany } from "@/global";
+import type { RouterOutput } from "@/trpc";
+import { trpc } from "@/trpc/client";
+import { formatMoneyFromCents } from "@/utils/formatMoney";
+import { formatDate } from "@/utils/time";
+import { export_company_liquidation_scenario_path } from "@/utils/routes";
+import EquityLayout from "../Layout";
+
+type Scenario = RouterOutput["liquidationScenarios"]["show"];
+
+export default function ScenarioPage() {
+  const { id } = useParams<{ id: string }>();
+  const company = useCurrentCompany();
+  const { data, isLoading } = trpc.liquidationScenarios.show.useQuery({ companyId: company.id, scenarioId: id });
+
+  const columnHelper = createColumnHelper<Scenario["payouts"][number]>();
+  const columns = useMemo(
+    () => [
+      columnHelper.simple("investorName", "Investor"),
+      columnHelper.simple("shareClass", "Share class"),
+      columnHelper.simple("securityType", "Security"),
+      columnHelper.simple(
+        "numberOfShares",
+        "Shares",
+        (v) => (v ? Number(v).toLocaleString() : "—"),
+        "numeric",
+      ),
+      columnHelper.simple(
+        "liquidationPreferenceAmount",
+        "Preference",
+        (v) => (v ? formatMoneyFromCents(v) : "—"),
+        "numeric",
+      ),
+      columnHelper.simple(
+        "participationAmount",
+        "Participation",
+        (v) => (v ? formatMoneyFromCents(v) : "—"),
+        "numeric",
+      ),
+      columnHelper.simple("payoutAmountCents", "Payout", formatMoneyFromCents, "numeric"),
+    ],
+    [],
+  );
+
+  const equityTable = useTable({ data: data?.payouts.filter(p => p.securityType === "equity") ?? [], columns });
+  const convertibleTable = useTable({ data: data?.payouts.filter(p => p.securityType === "convertible") ?? [], columns });
+
+  return (
+    <EquityLayout
+      headerActions={
+        <Button variant="outline" size="small" asChild>
+          <a href={export_company_liquidation_scenario_path(company.id, id)}>
+            <Download className="size-4" />
+            Download CSV
+          </a>
+        </Button>
+      }
+    >
+      {isLoading || !data ? (
+        <TableSkeleton columns={7} />
+      ) : (
+        <div className="grid gap-4">
+          <div className="grid gap-1">
+            <h2 className="text-xl font-semibold">{data.name}</h2>
+            {data.description ? <p>{data.description}</p> : null}
+            <div className="text-sm text-muted-foreground">
+              Exit amount: {formatMoneyFromCents(data.exitAmountCents)} · Exit date: {formatDate(data.exitDate)}
+            </div>
+          </div>
+          {data.payouts.length > 0 ? (
+            <>
+              {equityTable.getRowModel().rows.length > 0 && (
+                <div className="overflow-x-auto">
+                  <DataTable table={equityTable} caption="Equity" />
+                </div>
+              )}
+              {convertibleTable.getRowModel().rows.length > 0 && (
+                <div className="overflow-x-auto">
+                  <DataTable table={convertibleTable} caption="Convertibles" />
+                </div>
+              )}
+            </>
+          ) : (
+            <Placeholder>No payouts recorded</Placeholder>
+          )}
+        </div>
+      )}
+    </EquityLayout>
+  );
+}

--- a/frontend/app/equity/waterfall/new/page.tsx
+++ b/frontend/app/equity/waterfall/new/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarDate, getLocalTimeZone, today } from "@internationalized/date";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import DatePicker from "@/components/DatePicker";
+import MainLayout from "@/components/layouts/Main";
+import { MutationStatusButton } from "@/components/MutationButton";
+import NumberInput from "@/components/NumberInput";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useCurrentCompany } from "@/global";
+import { trpc } from "@/trpc/client";
+
+const formSchema = z.object({
+  name: z.string().min(1, "This field is required."),
+  description: z.string().optional(),
+  exitAmountCents: z.number().min(0),
+  exitDate: z.instanceof(CalendarDate),
+});
+
+export default function NewScenario() {
+  const company = useCurrentCompany();
+  const router = useRouter();
+
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      exitAmountCents: 0,
+      exitDate: today(getLocalTimeZone()),
+    },
+  });
+
+  const mutation = trpc.liquidationScenarios.run.useMutation({
+    onSuccess: (scenario) => {
+      router.push(`/equity/waterfall/${scenario.id}`);
+    },
+  });
+
+  const submit = form.handleSubmit(async (values) => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    await mutation.mutateAsync({
+      companyId: company.id,
+      name: values.name,
+      description: values.description || undefined,
+      exitAmountCents: BigInt(Math.round(values.exitAmountCents * 100)),
+      exitDate: values.exitDate.toDate(tz).toISOString(),
+    });
+  });
+
+  return (
+    <MainLayout
+      title="New scenario"
+      headerActions={
+        <Button variant="outline" asChild>
+          <a href="/equity/waterfall">Cancel</a>
+        </Button>
+      }
+    >
+      <Form {...form}>
+        <form onSubmit={(e) => void submit(e)} className="grid gap-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="exitAmountCents"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Exit amount</FormLabel>
+                <FormControl>
+                  <NumberInput {...field} decimal prefix="$" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="exitDate"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <DatePicker {...field} label="Exit date" granularity="day" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <MutationStatusButton type="submit" mutation={mutation} className="justify-self-end" loadingText="Creating...">
+            Create scenario
+          </MutationStatusButton>
+        </form>
+      </Form>
+    </MainLayout>
+  );
+}

--- a/frontend/app/equity/waterfall/page.tsx
+++ b/frontend/app/equity/waterfall/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { Plus, Download } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import React, { useMemo } from "react";
+import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
+import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
+import { Button } from "@/components/ui/button";
+import { useCurrentCompany, useCurrentUser } from "@/global";
+import type { RouterOutput } from "@/trpc";
+import { trpc } from "@/trpc/client";
+import { formatMoneyFromCents } from "@/utils/formatMoney";
+import { formatDate } from "@/utils/time";
+import { export_company_liquidation_scenarios_path } from "@/utils/routes";
+import EquityLayout from "../Layout";
+
+ type Scenario = RouterOutput["liquidationScenarios"]["list"][number];
+ const columnHelper = createColumnHelper<Scenario>();
+
+ export default function Waterfall() {
+   const company = useCurrentCompany();
+   const user = useCurrentUser();
+   const router = useRouter();
+   const isAdmin = !!user.roles.administrator;
+  const { data = [], isLoading } = trpc.liquidationScenarios.list.useQuery({ companyId: company.id });
+
+   const columns = useMemo(
+     () => [
+       columnHelper.accessor("name", { header: "Name", cell: (info) => <strong>{info.getValue()}</strong> }),
+       columnHelper.simple("exitAmountCents", "Exit amount", formatMoneyFromCents, "numeric"),
+       columnHelper.simple("exitDate", "Exit date", formatDate),
+       columnHelper.simple("status", "Status"),
+       columnHelper.simple("createdAt", "Created", formatDate),
+     ],
+     [],
+   );
+
+   const table = useTable({ data, columns });
+
+   return (
+     <EquityLayout
+       headerActions={
+         <div className="flex gap-2">
+           <Button variant="outline" size="small" asChild>
+             <a href={export_company_liquidation_scenarios_path(company.id)}>
+               <Download className="size-4" />
+               Download CSV
+             </a>
+           </Button>
+          {isAdmin && (
+            <Button size="small" asChild>
+              <Link href="/equity/waterfall/new">
+                <Plus className="size-4" />
+                New scenario
+              </Link>
+            </Button>
+          )}
+         </div>
+       }
+     >
+       {isLoading ? (
+         <TableSkeleton columns={5} />
+       ) : data.length > 0 ? (
+         <DataTable table={table} onRowClicked={(row) => router.push(`/equity/waterfall/${row.id}`)} />
+       ) : (
+         <Placeholder icon={Plus}>No scenarios yet.</Placeholder>
+       )}
+     </EquityLayout>
+   );
+ }


### PR DESCRIPTION
## Summary
- add Waterfall nav link
- implement scenario list view with CSV export and new scenario button
- create form to run new scenario
- show scenario details and payouts grouped by security type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687822f005ac8327b2270732d529f005