### PR TITLE
Fix invoice quantity parsing

### DIFF
--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -75,6 +75,7 @@ test.describe("Invoice submission, approval and rejection", () => {
     await expect(page.getByRole("heading", { name: "Edit invoice" })).toBeVisible();
     await page.getByPlaceholder("Description").first().fill("first item updated");
     const timeField = page.getByLabel("Hours / Qty").first();
+    await expect(timeField).toHaveValue("01:23");
     await timeField.fill("04:30");
     await timeField.blur(); // work around a test-specific issue; this works fine in a real browser
     await page.waitForTimeout(1000); // TODO (dani) avoid this
@@ -205,10 +206,12 @@ test.describe("Invoice submission, approval and rejection", () => {
     await expect(approvedInvoiceRow.getByRole("cell", { name: "Payment scheduled" })).toBeVisible();
     await expect(rejectedInvoiceRow.getByRole("cell", { name: "Rejected" })).toBeVisible();
 
-    await rejectedInvoiceRow.click({ button: "right" });
-    await page.getByRole("menuitem", { name: "Edit" }).click();
-    await expect(page.getByRole("heading", { name: "Edit invoice" })).toBeVisible();
-    await page.getByLabel("Hours / Qty").fill("02:30");
+  await rejectedInvoiceRow.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit" }).click();
+  await expect(page.getByRole("heading", { name: "Edit invoice" })).toBeVisible();
+  const rejectedTimeField = page.getByLabel("Hours / Qty");
+  await expect(rejectedTimeField).toHaveValue("00:23");
+  await rejectedTimeField.fill("02:30");
     await page.getByPlaceholder("Enter notes about your").fill("fixed hours");
     await page.waitForTimeout(200); // TODO (dani) avoid this
     await page.getByRole("button", { name: "Re-submit invoice" }).click();

--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -131,7 +131,10 @@ const Edit = () => {
     return List([
       {
         description: "",
-        quantity: (parseInt(searchParams.get("quantity") ?? "", 10) || (data.user.project_based ? 1 : 60)).toString(),
+        quantity: (
+          parseFloat(searchParams.get("quantity") ?? "") ||
+          (data.user.project_based ? 1 : 60)
+        ).toString(),
         hourly: searchParams.has("hourly") ? searchParams.get("hourly") === "true" : !data.user.project_based,
         pay_rate_in_subunits: parseInt(searchParams.get("rate") ?? "", 10) || (payRateInSubunits ?? 0),
       },
@@ -221,10 +224,13 @@ const Edit = () => {
     );
   };
 
+  const parseQuantity = (value: string | null | undefined) => {
+    const parsed = value ? Number.parseFloat(value) : NaN;
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
   const lineItemTotal = (lineItem: InvoiceFormLineItem) =>
-    Math.ceil(
-      ((parseFloat(lineItem.quantity ?? "0") || 0) / (lineItem.hourly ? 60 : 1)) * lineItem.pay_rate_in_subunits,
-    );
+    Math.ceil((parseQuantity(lineItem.quantity) / (lineItem.hourly ? 60 : 1)) * lineItem.pay_rate_in_subunits);
   const totalExpensesAmountInCents = expenses.reduce((acc, expense) => acc + expense.total_amount_in_cents, 0);
   const totalServicesAmountInCents = lineItems.reduce((acc, lineItem) => acc + lineItemTotal(lineItem), 0);
   const totalInvoiceAmountInCents = totalServicesAmountInCents + totalExpensesAmountInCents;
@@ -239,7 +245,7 @@ const Edit = () => {
         const updated = { ...assertDefined(lineItem), ...update };
         updated.errors = [];
         if (updated.description.length === 0) updated.errors.push("description");
-        if (!updated.quantity || parseFloat(updated.quantity) < 0.01) updated.errors.push("quantity");
+        if (!updated.quantity || parseQuantity(updated.quantity) < 0.01) updated.errors.push("quantity");
         return updated;
       }),
     );
@@ -348,7 +354,7 @@ const Edit = () => {
                   </TableCell>
                   <TableCell>
                     <QuantityInput
-                      value={item.quantity ? { quantity: parseFloat(item.quantity), hourly: item.hourly } : null}
+                      value={item.quantity ? { quantity: parseQuantity(item.quantity), hourly: item.hourly } : null}
                       aria-label="Hours / Qty"
                       aria-invalid={item.errors?.includes("quantity")}
                       onChange={(value) =>


### PR DESCRIPTION
## Summary
- parse invoice quantities as numbers from strings
- check default quantity values when editing invoices

## Testing
- `pnpm playwright test e2e/tests/company/invoices/complete-flow.spec.ts --grep "Invoice submission" --workers=1 --reporter=line` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6886f76125dc832790471cd5757c6dd7