### PR TITLE
Patch migrations for contract removal

### DIFF
--- a/backend/db/migrate/20231107101655_add_name_to_contract.rb
+++ b/backend/db/migrate/20231107101655_add_name_to_contract.rb
@@ -2,10 +2,9 @@ class AddNameToContract < ActiveRecord::Migration[7.1]
   def up
     add_column :contracts, :name, :string
 
-    Contract.reset_column_information
-    Contract.all.find_in_batches do |contracts|
-      Contract.where(id: contracts.map(&:id)).update_all(name: Document::CONSULTING_CONTRACT_NAME)
-    end
+    execute <<~SQL.squish
+      UPDATE contracts SET name = 'Consulting agreement'
+    SQL
 
     change_column_null :contracts, :name, false
   end

--- a/backend/db/migrate/20240426140240_add_company_id_to_contract.rb
+++ b/backend/db/migrate/20240426140240_add_company_id_to_contract.rb
@@ -3,11 +3,12 @@ class AddCompanyIdToContract < ActiveRecord::Migration[7.1]
     add_reference :contracts, :company
 
     up_only do
-      Contract.reset_column_information
-      Contract.find_each do |contract|
-        administrator = contract.company_administrator
-        contract.update_columns(company_id: administrator.company_id)
-      end
+      execute <<~SQL.squish
+        UPDATE contracts
+        SET company_id = company_administrators.company_id
+        FROM company_administrators
+        WHERE contracts.company_administrator_id = company_administrators.id
+      SQL
     end
 
     change_column_null :contracts, :company_id, false

--- a/backend/db/migrate/20240426141711_add_user_id_to_contract.rb
+++ b/backend/db/migrate/20240426141711_add_user_id_to_contract.rb
@@ -3,11 +3,12 @@ class AddUserIdToContract < ActiveRecord::Migration[7.1]
     add_reference :contracts, :user
 
     up_only do
-      Contract.reset_column_information
-      Contract.find_each do |contract|
-        contractor = contract.company_contractor
-        contract.update_columns(user_id: contractor.user_id)
-      end
+      execute <<~SQL.squish
+        UPDATE contracts
+        SET user_id = company_contractors.user_id
+        FROM company_contractors
+        WHERE contracts.company_contractor_id = company_contractors.id
+      SQL
     end
 
     change_column_null :contracts, :user_id, false


### PR DESCRIPTION
## Summary
- clean up migrations referencing the removed `Contract` model
- replace loops with SQL updates so migrations run without model classes

## Testing
- `bundle --version` *(fails: ruby not installed)*
- `pnpm --version` *(fails: can't download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6887beea3d6c832782549ec74c2d5928