### PR TITLE
Add ContractorWiseRecipient model to migration

### DIFF
--- a/backend/db/migrate/20230922000144_add_used_for_invoices_and_dividends.rb
+++ b/backend/db/migrate/20230922000144_add_used_for_invoices_and_dividends.rb
@@ -1,4 +1,9 @@
 class AddUsedForInvoicesAndDividends < ActiveRecord::Migration[7.0]
+  class ContractorWiseRecipient < ApplicationRecord
+    self.table_name = 'wise_recipients'
+    scope :alive, -> { where(deleted_at: nil) }
+  end
+
   def up
     change_table :wise_recipients do |t|
       t.boolean :used_for_invoices, default: false, null: false


### PR DESCRIPTION
## Summary
- add inner `ContractorWiseRecipient` model in migration `AddUsedForInvoicesAndDividends`

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `pnpm playwright test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6888de1b92788327ab1fea1c58d08a36