### PR TITLE
Add CompanyWorkerUpdate class to migration

### DIFF
--- a/backend/db/migrate/20241218131314_add_company_id_to_company_contractor_updates.rb
+++ b/backend/db/migrate/20241218131314_add_company_id_to_company_contractor_updates.rb
@@ -1,4 +1,9 @@
 class AddCompanyIdToCompanyContractorUpdates < ActiveRecord::Migration[7.2]
+  class CompanyWorkerUpdate < ApplicationRecord
+    self.table_name = 'company_contractor_updates'
+    belongs_to :company_worker, class_name: 'CompanyWorker'
+  end
+
   def change
     add_reference :company_contractor_updates, :company, index: true
 


### PR DESCRIPTION
## Summary
- define a `CompanyWorkerUpdate` model inside the migration
- keep the existing data migration loop intact

## Testing
- `bundle exec rspec` *(fails: `command not found: bundle`)*

------
https://chatgpt.com/codex/tasks/task_e_6888de21b8988327aab025d1e1b6f98f