### PR TITLE
Add class for contractor absence migration

### DIFF
--- a/backend/db/migrate/20241218131323_add_company_id_to_company_contractor_absences.rb
+++ b/backend/db/migrate/20241218131323_add_company_id_to_company_contractor_absences.rb
@@ -1,3 +1,8 @@
+class CompanyWorkerAbsence < ApplicationRecord
+  self.table_name = 'company_contractor_absences'
+  belongs_to :company_worker, class_name: 'CompanyWorker'
+end
+
 class AddCompanyIdToCompanyContractorAbsences < ActiveRecord::Migration[7.2]
   def change
     add_reference :company_contractor_absences, :company, index: true


### PR DESCRIPTION
## Summary
- add `CompanyWorkerAbsence` model to `add_company_id_to_company_contractor_absences` migration

## Testing
- `bundle exec rspec spec/models/company_worker_spec.rb -fd` *(fails: bundle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888de24ce7c8327b3d4d24f5c3b5cb6