### PR TITLE
Add stub models to migration

### DIFF
--- a/backend/db/migrate/20250129233958_merge_company_worker_update_tasks.rb
+++ b/backend/db/migrate/20250129233958_merge_company_worker_update_tasks.rb
@@ -1,4 +1,14 @@
 class MergeCompanyWorkerUpdateTasks < ActiveRecord::Migration[7.2]
+  class CompanyWorkerUpdateTask < ApplicationRecord
+    self.table_name = 'company_contractor_update_tasks'
+    belongs_to :task
+  end
+
+  class Task < ApplicationRecord
+    self.table_name = 'tasks'
+    has_many :integration_records, as: :integratable, class_name: 'IntegrationRecord'
+  end
+
   def change
     change_table :company_contractor_update_tasks do |t|
       t.text :name


### PR DESCRIPTION
## Summary
- stub `CompanyWorkerUpdateTask` model in migration
- add minimal `Task` model to make `task.integration_records` work

## Testing
- `bundle exec rspec` *(fails: `/usr/bin/env: ‘ruby’: No such file or directory`)*
- `pnpm playwright test` *(fails: could not download pnpm due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6888de270aa08327a923f2a79a4aec08