### PR TITLE
Fix ContractorProfile migration

### DIFF
--- a/backend/db/migrate/20240728133904_make_contractor_profile_external_id_required.rb
+++ b/backend/db/migrate/20240728133904_make_contractor_profile_external_id_required.rb
@@ -1,3 +1,7 @@
+class ContractorProfile < ApplicationRecord
+  self.table_name = 'contractor_profiles'
+end
+
 class MakeContractorProfileExternalIdRequired < ActiveRecord::Migration[7.1]
   def change
     up_only do


### PR DESCRIPTION
## Summary
- add local ContractorProfile model to the migration

## Testing
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888de29d17083278db353fa2fee1679