### PR TITLE
Insert Contract model in contract migrations

### DIFF
--- a/backend/db/migrate/20230823174411_add_signatures_to_contracts.rb
+++ b/backend/db/migrate/20230823174411_add_signatures_to_contracts.rb
@@ -1,3 +1,10 @@
+class Contract < ApplicationRecord
+  self.table_name = 'contracts'
+  CONSULTING_CONTRACT_NAME = Document::CONSULTING_CONTRACT_NAME
+  belongs_to :company_contractor, class_name: 'CompanyWorker', optional: true
+  belongs_to :company_administrator
+end
+
 class AddSignaturesToContracts < ActiveRecord::Migration[7.0]
   def up
     add_column :contracts, :contractor_signature, :string

--- a/backend/db/migrate/20231107101655_add_name_to_contract.rb
+++ b/backend/db/migrate/20231107101655_add_name_to_contract.rb
@@ -1,3 +1,10 @@
+class Contract < ApplicationRecord
+  self.table_name = 'contracts'
+  CONSULTING_CONTRACT_NAME = Document::CONSULTING_CONTRACT_NAME
+  belongs_to :company_contractor, class_name: 'CompanyWorker', optional: true
+  belongs_to :company_administrator
+end
+
 class AddNameToContract < ActiveRecord::Migration[7.1]
   def up
     add_column :contracts, :name, :string

--- a/backend/db/migrate/20240426140240_add_company_id_to_contract.rb
+++ b/backend/db/migrate/20240426140240_add_company_id_to_contract.rb
@@ -1,3 +1,10 @@
+class Contract < ApplicationRecord
+  self.table_name = 'contracts'
+  CONSULTING_CONTRACT_NAME = Document::CONSULTING_CONTRACT_NAME
+  belongs_to :company_contractor, class_name: 'CompanyWorker', optional: true
+  belongs_to :company_administrator
+end
+
 class AddCompanyIdToContract < ActiveRecord::Migration[7.1]
   def change
     add_reference :contracts, :company

--- a/backend/db/migrate/20240426141711_add_user_id_to_contract.rb
+++ b/backend/db/migrate/20240426141711_add_user_id_to_contract.rb
@@ -1,3 +1,10 @@
+class Contract < ApplicationRecord
+  self.table_name = 'contracts'
+  CONSULTING_CONTRACT_NAME = Document::CONSULTING_CONTRACT_NAME
+  belongs_to :company_contractor, class_name: 'CompanyWorker', optional: true
+  belongs_to :company_administrator
+end
+
 class AddUserIdToContract < ActiveRecord::Migration[7.1]
   def change
     add_reference :contracts, :user


### PR DESCRIPTION
## Summary
- add a lightweight `Contract` model to older migrations that need it

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `pnpm playwright test` *(fails: could not download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6888de2cb37c83278d39da34f33fad75