### PR TITLE
Add ExpenseCard models for migrations

### DIFF
--- a/backend/db/migrate/20240728222358_add_expense_card_processor_columns.rb
+++ b/backend/db/migrate/20240728222358_add_expense_card_processor_columns.rb
@@ -1,3 +1,7 @@
+class ExpenseCard < ApplicationRecord
+  self.table_name = 'expense_cards'
+end
+
 class AddExpenseCardProcessorColumns < ActiveRecord::Migration[7.1]
   def change
     create_enum :expense_cards_processors, %w[stripe]

--- a/backend/db/migrate/20240820210617_change_stripe_naming_from_expense_card_charges.rb
+++ b/backend/db/migrate/20240820210617_change_stripe_naming_from_expense_card_charges.rb
@@ -1,3 +1,7 @@
+class ExpenseCardCharge < ApplicationRecord
+  self.table_name = 'expense_card_charges'
+end
+
 class ChangeStripeNamingFromExpenseCardCharges < ActiveRecord::Migration[7.1]
   def change
     add_column :expense_card_charges, :processor_transaction_reference, :string


### PR DESCRIPTION
## Summary
- add inline `ExpenseCard` model to AddExpenseCardProcessorColumns migration
- add inline `ExpenseCardCharge` model to ChangeStripeNamingFromExpenseCardCharges migration

## Testing
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888de30a6808327b7a3716709f88159