### PR TITLE
Fix invoice flow test navigation

### DIFF
--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -198,6 +198,8 @@ test.describe("Invoice submission, approval and rejection", () => {
 
     await clerk.signOut({ page });
     await login(page, workerUserA);
+    await page.getByRole("link", { name: "Invoices" }).click();
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
 
     const approvedInvoiceRow = page.locator("tbody tr").filter({ hasText: "CUSTOM-1" });
     const rejectedInvoiceRow = page.locator("tbody tr").filter({ hasText: "CUSTOM-2" });


### PR DESCRIPTION
## Summary
- ensure invoice flow test clicks to the Invoices page after login

## Testing
- `pnpm lint-fast --max-warnings 0 --fix --no-warn-ignored` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb3d76848327b3612da2dd13172f