### PR TITLE
Fix dividend modal wait

### DIFF
--- a/e2e/tests/company/equity/dividends.spec.ts
+++ b/e2e/tests/company/equity/dividends.spec.ts
@@ -72,10 +72,10 @@ test.describe("Dividends", () => {
         await modal.getByRole("button", { name: "Add your signature" }).click();
         await expect(modal.getByText(assertDefined(investorUser.legalName))).toHaveCount(2);
         await modal.getByRole("button", { name: "Accept funds" }).click();
+        await page.getByRole("dialog").waitFor({ state: "hidden" });
       },
       { page },
     );
-    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Sign" })).not.toBeVisible();
 
     const updatedDividend = await db.query.dividends


### PR DESCRIPTION
## Summary
- ensure dividend signing waits for the modal to close before continuing

## Testing
- `pnpm lint-fast --max-warnings 0 --fix --no-warn-ignored` *(fails: Request was cancelled due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb41f4f08327a0b87b5283df65d0