### PR TITLE
Sort user compliance infos before assertions

### DIFF
--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -183,10 +183,14 @@ test.describe("Tax settings", () => {
         .then(takeOrThrow);
       expect(updatedUser.userComplianceInfos).toHaveLength(2);
 
-      expect(updatedUser.userComplianceInfos[0]?.deletedAt).not.toBeNull();
+      const infos = updatedUser.userComplianceInfos.sort((a, b) =>
+        Number(a.id - b.id),
+      );
 
-      expect(updatedUser.userComplianceInfos[1]?.taxInformationConfirmedAt).not.toBeNull();
-      expect(updatedUser.userComplianceInfos[1]?.deletedAt).toBeNull();
+      expect(infos[0]?.deletedAt).not.toBeNull();
+
+      expect(infos[1]?.taxInformationConfirmedAt).not.toBeNull();
+      expect(infos[1]?.deletedAt).toBeNull();
     });
 
     // TODO (techdebt): Add the quickbooks tests from spec/system/settings/tax_spec.rb


### PR DESCRIPTION
## Summary
- ensure user compliance infos are sorted before checking deletion status

## Testing
- `pnpm lint-fast` *(fails: unable to download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb505d8483278ede739156deb98c