### PR TITLE
Fix date picker overlay

### DIFF
--- a/e2e/tests/company/equity/dividends.spec.ts
+++ b/e2e/tests/company/equity/dividends.spec.ts
@@ -72,10 +72,10 @@ test.describe("Dividends", () => {
         await modal.getByRole("button", { name: "Add your signature" }).click();
         await expect(modal.getByText(assertDefined(investorUser.legalName))).toHaveCount(2);
         await modal.getByRole("button", { name: "Accept funds" }).click();
-        await page.getByRole("dialog").waitFor({ state: "hidden" });
       },
       { page },
     );
+    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Sign" })).not.toBeVisible();
 
     const updatedDividend = await db.query.dividends

--- a/e2e/tests/company/equity/dividends.spec.ts
+++ b/e2e/tests/company/equity/dividends.spec.ts
@@ -72,10 +72,10 @@ test.describe("Dividends", () => {
         await modal.getByRole("button", { name: "Add your signature" }).click();
         await expect(modal.getByText(assertDefined(investorUser.legalName))).toHaveCount(2);
         await modal.getByRole("button", { name: "Accept funds" }).click();
+        await page.getByRole("dialog").waitFor({ state: "hidden" });
       },
       { page },
     );
-    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Sign" })).not.toBeVisible();
 
     const updatedDividend = await db.query.dividends

--- a/e2e/tests/company/people/date-picker.spec.ts
+++ b/e2e/tests/company/people/date-picker.spec.ts
@@ -1,0 +1,22 @@
+import { companiesFactory } from "@test/factories/companies";
+import { usersFactory } from "@test/factories/users";
+import { login } from "@test/helpers/auth";
+import { expect, test, withinModal } from "@test/index";
+
+test("can select start date with date picker", async ({ page }) => {
+  const { company, adminUser } = await companiesFactory.createCompletedOnboarding();
+  const workerUser = (await usersFactory.create()).user;
+  await login(page, adminUser);
+  await page.goto("/people");
+  await page.getByRole("button", { name: "Add contractor" }).click();
+  await withinModal(
+    async (modal) => {
+      await modal.getByLabel("Email").fill(workerUser.email);
+      await modal.getByRole("button", { name: "Calendar" }).click();
+      await modal.getByRole("gridcell", { name: "15" }).first().click();
+      await expect(modal.getByRole("group", { name: "Start date" })).toContainText("15");
+    },
+    { page, title: "Who's joining?" },
+  );
+});
+

--- a/frontend/components/DatePicker.tsx
+++ b/frontend/components/DatePicker.tsx
@@ -32,7 +32,7 @@ export default function DatePicker({ label, className, ...props }: DatePickerPro
       </div>
       <RacPopover
         placement="bottom end"
-        className="bg-background text-popover-foreground data-entering:animate-in data-exiting:animate-out data-[entering]:fade-in-0 data-[exiting]:fade-out-0 data-[entering]:zoom-in-95 data-[exiting]:zoom-out-95 data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2 z-50 rounded-lg border shadow-lg outline-hidden"
+        className="bg-background text-popover-foreground data-entering:animate-in data-exiting:animate-out data-[entering]:fade-in-0 data-[exiting]:fade-out-0 data-[entering]:zoom-in-95 data-[exiting]:zoom-out-95 data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2 z-[60] rounded-lg border shadow-lg outline-hidden"
       >
         <RacDialog className="max-h-[inherit] overflow-auto p-2">
           <Calendar />


### PR DESCRIPTION
## Summary
- raise date picker popover z-index so it sits above dialog overlay
- test date picker in contractor invite modal

## Testing
- `pnpm playwright test e2e/tests/company/people/date-picker.spec.ts --project=chromium` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68893504379083279ff1655cb0c15fb8